### PR TITLE
place LCD and AUDIO section in RAM

### DIFF
--- a/STM32H7B0VBTx_FLASH.ld
+++ b/STM32H7B0VBTx_FLASH.ld
@@ -200,6 +200,24 @@ SECTIONS
     libgcc.a ( * )
   }
 
+.lcd :
+  {
+    _lcdstart = .;
+    . = ALIGN(4);
+    *(.lcd)
+    . = ALIGN(4);
+    _lcdend = .;
+  } > RAM
+
+    .audio :
+  {
+    _audiostart = .;
+    . = ALIGN(4);
+    *(.audio)
+    . = ALIGN(4);
+    _audioend = .;
+  } > RAM
+
   .ARM.attributes 0 : { *(.ARM.attributes) }
 }
 


### PR DESCRIPTION
Added specification that make it clear for the linter to put the framebuffer in RAM so it won't return an error due to FLASH  overflow